### PR TITLE
Updating dtype of `np.nextafter`

### DIFF
--- a/src/tracksdata/functional/_apply.py
+++ b/src/tracksdata/functional/_apply.py
@@ -171,10 +171,11 @@ def _yield_apply_tiled(
 
     for corner in tiles_corner:
         # corner considers the overlap, so right needs to be shifted by 2 * o
-        # eps is because tracksdata filter slicing is inclusive
+        # np.nextafter is used to convert inclusive to exclusive ranges.
         # it varies with the scale due to numerical precision of spatial-graph rtree queries
         slicing_without_overlap = tuple(
-            slice(c, c + t - np.spacing(c)) for c, t in zip(corner, tiling_scheme.tile_shape, strict=True)
+            slice(c, np.nextafter(c + t, -np.inf, dtype=np.float32))
+            for c, t in zip(corner, tiling_scheme.tile_shape, strict=True)
         )
         graph_filter_without_overlap = spatial_filter[slicing_without_overlap]
 
@@ -183,7 +184,7 @@ def _yield_apply_tiled(
             graph_filter = graph_filter_without_overlap
         else:
             slicing = tuple(
-                slice(s.start - o, s.stop + o)
+                slice(s.start - o, np.nextafter(s.stop + o, -np.inf, dtype=np.float32))
                 for s, o in zip(slicing_without_overlap, tiling_scheme.overlap_shape, strict=True)
             )
             graph_filter = spatial_filter[slicing]

--- a/src/tracksdata/functional/_test/test_apply.py
+++ b/src/tracksdata/functional/_test/test_apply.py
@@ -137,6 +137,8 @@ def test_apply_tiled_2d_tiling() -> None:
       |
       ---------------------y
      0   5   10   15   20
+
+     Note: tile range is (0-0, 5-14, 10-30)
     """
 
     scheme = TilingScheme(
@@ -144,6 +146,12 @@ def test_apply_tiled_2d_tiling() -> None:
         overlap_shape=(0, 5, 5),
         attrs=["t", "y", "x"],
     )
+
+    """
+    Tile layout (with overlap):
+    # tile ids to corners
+    # 0 : (0-1, 5-15, 10-30)
+    """
 
     tiles_corner = _get_tiles_corner(
         start=[0, 5, 10],


### PR DESCRIPTION
I believe the test-failing issue in https://github.com/royerlab/tracksdata/pull/183 is because of float64->float32 cast in `rtree`. I updated the dtype of `np.nextafter` to `float32` and now tests are passing.